### PR TITLE
fixed bug in macrotools.py

### DIFF
--- a/CosmicEndpoint/test/macrotools.py
+++ b/CosmicEndpoint/test/macrotools.py
@@ -118,7 +118,7 @@ ls -tar
 root -b -q -x %s
 tree
 echo "rsync \"ssh -T -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null\" -aAXch --progress ${OUTPUTDIR} %s:/tmp/${USER}/"
-rsync "ssh -T -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" -aAXch --progress ${OUTPUTDIR} %s:/tmp/${USER}/
+rsync -e "ssh -T -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" -aAXch --progress ${OUTPUTDIR} %s:/tmp/${USER}/
 """%(proxyPath,
      #logfile,logfile,
      1000*maxBias,minPt,nBiasBins,
@@ -131,7 +131,8 @@ rsync "ssh -T -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" -aAXc
 	f.close()
 	os.chmod(subfile, 0777)
 	# cmd = "bsub -q test -W 0:20 %s/%s"%(subfile) #submit to the test queue if debug (only a single job though
-	cmd = "bsub -q 8nm -W 0:10 %s"%(subfile)
+	#cmd = "bsub -q 8nm -W 0:10 %s"%(subfile)
+	cmd = "bsub -q 1nh -W 0:30 %s"%(subfile)
 	print cmd
 	if not debug:
 		os.system(cmd)

--- a/CosmicEndpoint/test/macrotools.py
+++ b/CosmicEndpoint/test/macrotools.py
@@ -131,8 +131,8 @@ rsync -e "ssh -T -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" -a
 	f.close()
 	os.chmod(subfile, 0777)
 	# cmd = "bsub -q test -W 0:20 %s/%s"%(subfile) #submit to the test queue if debug (only a single job though
-	#cmd = "bsub -q 8nm -W 0:10 %s"%(subfile)
-	cmd = "bsub -q 1nh -W 0:30 %s"%(subfile)
+	cmd = "bsub -q 8nm -W 0:20 %s"%(subfile)
+	#cmd = "bsub -q 1nh -W 0:30 %s"%(subfile)
 	print cmd
 	if not debug:
 		os.system(cmd)


### PR DESCRIPTION
Problem for the 255 error was in the passing of some ssh options, I must have gotten lucky on the node my job ran on since it didn't catch this in the original commit
The other problem, I can't reproduce, so I increased the time estimate to 20 minutes (my jobs always ran for at most 3 minutes so this should be sufficient)  They're submitted to the 8nm queue, but there's another line you can comment out that will instead use the 1nh queue
